### PR TITLE
Add get and generate_url methods to UrlboxClient.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,21 @@
+---
 AllCops:
   Exclude:
     - '*.gemspec'
   TargetRubyVersion: 2.5
-Style/FrozenStringLiteralComment:
-  Enabled: false
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - test/**/*
+Metrics/ClassLength:
+  Enabled: true
+  Exclude:
+    - test/**/*
+Metrics/MethodLength:
+  Enabled: true
+  Exclude:
+    - test/**/*
 Style/Documentation:
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'http'
+
 group :development do
   gem 'minitest'
   gem 'rake'


### PR DESCRIPTION
#### What's this PR do?
Adds get and generate_url methods to UrlboxClient.

#### Background context
Following the same design as the python package.

Uses the HTTP gem as a http client to make requests to the Urlbox API

ref:
https://github.com/httprb/http