### PR TITLE
Add dynamic class methods to allow magic module like behaviour.

### DIFF
--- a/lib/urlbox/errors.rb
+++ b/lib/urlbox/errors.rb
@@ -1,3 +1,10 @@
 module Urlbox
-  class UrlboxError < StandardError; end
+  class UrlboxError < StandardError
+    def self.missing_api_secret_error_message
+      <<-ERROR_MESSAGE
+        Missing api_secret when initialising client or ENV['URLBOX_API_SECRET'] not set.
+        Required for authorised post request.
+      ERROR_MESSAGE
+    end
+  end
 end

--- a/lib/urlbox_client.rb
+++ b/lib/urlbox_client.rb
@@ -32,7 +32,7 @@ class UrlboxClient
   end
 
   def post(options)
-    raise Urlbox::UrlboxError, missing_api_secret_error_message if @api_secret.nil?
+    raise Urlbox::UrlboxError, Urlbox::UrlboxError.missing_api_secret_error_message if @api_secret.nil?
 
     unless options.key?(:webhook_url)
       warn('webhook_url not supplied, you will need to poll the statusUrl in order to get your result')
@@ -78,13 +78,6 @@ class UrlboxClient
     else
       BASE_API_URL
     end
-  end
-
-  def missing_api_secret_error_message
-    <<-ERROR_MESSAGE
-      Missing api_secret when initialising client or ENV['URLBOX_API_SECRET'] not set.
-      Required for authorised post request.
-    ERROR_MESSAGE
   end
 
   def process_options(options, url_encode_options: true)

--- a/test/test_urlbox_client.rb
+++ b/test/test_urlbox_client.rb
@@ -365,7 +365,6 @@ class UrlboxClientTest < Minitest::Test
     }
 
     ClimateControl.modify URLBOX_API_KEY: api_key, URLBOX_API_SECRET: api_secret do
-
       stub_request(:post, 'https://api.urlbox.io/v1/render')
         .with(
           body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",


### PR DESCRIPTION
#### What's this PR do?
Adds dynamic class methods to allow magic module like behaviour.

#### Background context
Instead of needing to instantiate a class, you can use the class methods
that wrap the instance methods directly on the class.

As long as the Urlbox ENV VARs are set, then you can use this like so:

```ruby
Urlbox.get({url: 'http://www.google.com'})
Urlbox.post({url: 'http://www.google.com'})
Urlbox.head({url: 'http://www.google.com'})
Urlbox.delete({url: 'http://www.google.com'})
```

Instead of:
```ruby
urlbox_client = UrlboxClient.new(api_key: api_key, api_secret: api_secret)

urlbox_client.get({url: 'http://www.google.com'})
etc...
```

#### Where should the reviewer start?

This is the magic/ meta programming:
https://github.com/urlbox/urlbox-ruby/compare/add-dynamic-class-methods?expand=1#diff-fd6a510312bef7e0154b69a5e88d068124d821b5826bec1344ccd2eb38dd0ff3R65-R72
```ruby
 class << self
    %i[get delete head post].each do |method|
      self.define_method(method) do |options|
        new.send(method, options)
      end
    end
  end
```

This:
1) opens up the class using class << self
2) loops through the array of method names, 
3) uses define_method to create a class method using each of the method names, that accepts an options (hash) param
4) each of these methods calls new, to create an instance of the UrlboxClient class, and then calls the instance method (get, head, delete, post) and passes in the options hash to this.

So the dynamically create class method wraps the instance method, written long form:

```ruby
class UrlBoxClient
  def self.get(options)
    new.get(options)
  end
end
``

