### PR TITLE
Refactor UrlboxClient -> Urlbox::Client and Urlbox::Error

### DIFF
--- a/lib/urlbox/client.rb
+++ b/lib/urlbox/client.rb
@@ -1,0 +1,130 @@
+require 'http'
+require 'urlbox/error'
+
+module Urlbox
+  class Client
+    BASE_API_URL = 'https://api.urlbox.io/v1/'.freeze
+    POST_END_POINT = 'render'.freeze
+
+    def initialize(api_key: nil, api_secret: nil, api_host_name: nil)
+      if api_key.nil? && ENV['URLBOX_API_KEY'].nil?
+        raise Urlbox::Error, "Missing api_key or ENV['URLBOX_API_KEY'] not set"
+      end
+
+      @api_key = api_key || ENV['URLBOX_API_KEY']
+      @api_secret = api_secret || ENV['URLBOX_API_SECRET']
+      @base_api_url = init_base_api_url(api_host_name)
+    end
+
+    def get(options)
+      HTTP.timeout(100).follow.get(generate_url(options))
+    end
+
+    def delete(options)
+      processed_options, format = process_options(options)
+      HTTP.delete("#{@base_api_url}#{@api_key}/#{format}?#{processed_options}")
+    end
+
+    def head(options)
+      processed_options, format = process_options(options)
+      HTTP.timeout(100)
+          .follow
+          .head("#{@base_api_url}#{@api_key}/#{format}?#{processed_options}")
+    end
+
+    def post(options)
+      raise Urlbox::Error, Urlbox::Error.missing_api_secret_error_message if @api_secret.nil?
+
+      unless options.key?(:webhook_url)
+        warn('webhook_url not supplied, you will need to poll the statusUrl in order to get your result')
+      end
+
+      processed_options, _format = process_options_post_request(options)
+      HTTP.timeout(5)
+          .headers('Content-Type': 'application/json', 'Authorization': "Bearer #{@api_secret}")
+          .post("#{@base_api_url}#{POST_END_POINT}", json: processed_options)
+    end
+
+    # TODO: extract out to its own class
+    def generate_url(options)
+      processed_options, format = process_options(options)
+
+      if @api_secret
+        "#{@base_api_url}" \
+        "#{@api_key}/#{token(processed_options)}/#{format}" \
+        "?#{processed_options}"
+      else
+        "#{@base_api_url}" \
+        "#{@api_key}/#{format}" \
+        "?#{processed_options}"
+      end
+    end
+
+    # class methods to allow easy env var based usage
+    class << self
+      %i[get delete head post].each do |method|
+        define_method(method) do |options|
+          new.send(method, options)
+        end
+      end
+    end
+
+    private
+
+    def init_base_api_url(api_host_name)
+      if api_host_name
+        "https://#{api_host_name}/"
+      elsif ENV['URLBOX_API_HOST_NAME']
+        ENV['URLBOX_API_HOST_NAME']
+      else
+        BASE_API_URL
+      end
+    end
+
+    def process_options(options, url_encode_options: true)
+      processed_options = options.transform_keys(&:to_sym)
+
+      raise_key_error_if_missing_required_keys(processed_options)
+
+      processed_options[:url] = process_url(processed_options[:url]) if processed_options[:url]
+      processed_options[:format] = processed_options.fetch(:format, 'png')
+
+      if url_encode_options
+        [URI.encode_www_form(processed_options), processed_options[:format]]
+      else
+        [processed_options, processed_options[:format]]
+      end
+    end
+
+    def process_options_post_request(options)
+      process_options(options, url_encode_options: false)
+    end
+
+    def prepend_schema(url)
+      url.start_with?('http') ? url : "http://#{url}"
+    end
+
+    def process_url(url)
+      url_parsed = prepend_schema(url.strip)
+
+      raise Urlbox::Error, "Invalid URL: #{url_parsed}" unless valid_url?(url_parsed)
+
+      url_parsed
+    end
+
+    def raise_key_error_if_missing_required_keys(options)
+      return unless options[:url].nil? && options[:html].nil?
+
+      raise Urlbox::Error, 'Missing url or html entry in options'
+    end
+
+    def token(url_encoded_options)
+      OpenSSL::HMAC.hexdigest('sha1', @api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
+    end
+
+    def valid_url?(url)
+      parsed_url = URI.parse(url)
+      !parsed_url.host.nil? && parsed_url.host.include?('.')
+    end
+  end
+end

--- a/lib/urlbox/error.rb
+++ b/lib/urlbox/error.rb
@@ -1,5 +1,5 @@
 module Urlbox
-  class UrlboxError < StandardError
+  class Error < StandardError
     def self.missing_api_secret_error_message
       <<-ERROR_MESSAGE
         Missing api_secret when initialising client or ENV['URLBOX_API_SECRET'] not set.

--- a/test/test_urlbox_client.rb
+++ b/test/test_urlbox_client.rb
@@ -1,370 +1,232 @@
 require 'climate_control'
 require 'minitest/autorun'
-require 'urlbox_client'
+require 'urlbox/client'
 require 'webmock/minitest'
 
-class UrlboxClientTest < Minitest::Test
-  # test_init
-  def test_no_api_key_provided_and_env_var_not_set
-    e = assert_raises Urlbox::UrlboxError do
-      UrlboxClient.new
+module Urlbox
+  class ClientTest < Minitest::Test
+    # test_init
+    def test_no_api_key_provided_and_env_var_not_set
+      e = assert_raises Urlbox::Error do
+        Urlbox::Client.new
+      end
+
+      assert_equal e.message, "Missing api_key or ENV['URLBOX_API_KEY'] not set"
     end
 
-    assert_equal e.message, "Missing api_key or ENV['URLBOX_API_KEY'] not set"
-  end
+    def test_no_api_key_provided_but_env_var_is_set
+      env_var_api_key = 'ENV_VAR_KEY'
 
-  def test_no_api_key_provided_but_env_var_is_set
-    env_var_api_key = 'ENV_VAR_KEY'
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        urlbox_client = Urlbox::Client.new
 
-    ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-      urlbox_client = UrlboxClient.new
-
-      # It doesn't throw an error and sets the api_key with the env var value
-      assert_equal urlbox_client.instance_variable_get(:@api_key), env_var_api_key
-    end
-  end
-
-  def test_api_key_provided_and_env_var_is_set
-    env_var_api_key = 'ENV_VAR_KEY'
-    param_api_key = 'PARAM_KEY'
-
-    ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-      urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-      # It sets the api_key with the param, not the env var, value
-      assert_equal urlbox_client.instance_variable_get(:@api_key), param_api_key
-    end
-  end
-
-  def test_no_api_secret_provided_but_env_var_is_set
-    env_var_api_secret = 'ENV_VAR_SECRET'
-    param_api_key = 'PARAM_KEY'
-
-    ClimateControl.modify URLBOX_API_SECRET: env_var_api_secret do
-      urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-      assert_equal urlbox_client.instance_variable_get(:@api_secret), env_var_api_secret
-    end
-  end
-
-  def test_api_secret_provided_and_env_var_is_set
-    env_var_api_secret = 'ENV_VAR_SECRET'
-    param_api_secret = 'PARAM_SECRET'
-    param_api_key = 'PARAM_KEY'
-
-    ClimateControl.modify URLBOX_API_SECRET: env_var_api_secret do
-      urlbox_client = UrlboxClient.new(api_key: param_api_key, api_secret: param_api_secret)
-
-      # It sets the api_secret with the param, not the env var, value
-      assert_equal urlbox_client.instance_variable_get(:@api_secret), param_api_secret
-    end
-  end
-
-  def test_api_host_name_provided
-    param_api_key = 'PARAM_KEY'
-    api_host_name = ['api-eu.urlbox.io', 'api-direct.urlbox.io'].sample
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key, api_host_name: api_host_name)
-
-    # Use the api_host_name
-    assert_equal urlbox_client.instance_variable_get(:@base_api_url), "https://#{api_host_name}/"
-  end
-
-  def test_no_api_host_name_provided
-    param_api_key = 'PARAM_KEY'
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    # Use the default BASE_API_URL
-    assert_equal urlbox_client.instance_variable_get(:@base_api_url), UrlboxClient::BASE_API_URL
-  end
-
-  def test_no_api_host_name_provided_but_env_var_is_set
-    param_api_key = 'PARAM_KEY'
-    env_var_api_host_name = 'ENV_VAR_HOST_NAME'
-
-    ClimateControl.modify URLBOX_API_HOST_NAME: env_var_api_host_name do
-      urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-      assert_equal env_var_api_host_name, urlbox_client.instance_variable_get(:@base_api_url)
-    end
-  end
-
-  # Test get
-  def test_successful_get_request
-    param_api_key = 'KEY'
-    options = { url: 'https://www.example.com' }
-
-    stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
-      .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    response = urlbox_client.get(options)
-
-    assert response.status == 200
-    assert response.headers['Content-Type'].include?('png')
-  end
-
-  def test_successful_get_request_no_schema_url
-    param_api_key = 'KEY'
-    options = { url: 'www.example.com' }
-
-    stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=http://www.example.com")
-      .to_return(status: 200, body: '', headers: {})
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    response = urlbox_client.get(options)
-
-    assert response.status == 200
-  end
-
-  def test_unsuccessful_get_invalid_url
-    param_api_key = 'KEY'
-    options = { url: 'FOO' }
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    e = assert_raises Urlbox::UrlboxError do
-      urlbox_client.get(options)
+        # It doesn't throw an error and sets the api_key with the env var value
+        assert_equal urlbox_client.instance_variable_get(:@api_key), env_var_api_key
+      end
     end
 
-    assert_equal e.message, 'Invalid URL: http://FOO'
-  end
+    def test_api_key_provided_and_env_var_is_set
+      env_var_api_key = 'ENV_VAR_KEY'
+      param_api_key = 'PARAM_KEY'
 
-  def test_unsuccessful_get_missing_url_or_html_entry_in_options
-    param_api_key = 'KEY'
-    options = { format: 'png' }
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        urlbox_client = Urlbox::Client.new(api_key: param_api_key)
 
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    e = assert_raises Urlbox::UrlboxError do
-      urlbox_client.get(options)
+        # It sets the api_key with the param, not the env var, value
+        assert_equal urlbox_client.instance_variable_get(:@api_key), param_api_key
+      end
     end
 
-    assert_equal e.message, 'Missing url or html entry in options'
-  end
+    def test_no_api_secret_provided_but_env_var_is_set
+      env_var_api_secret = 'ENV_VAR_SECRET'
+      param_api_key = 'PARAM_KEY'
 
-  def test_successful_get_request_authenticated
-    api_key = 'KEY'
-    api_secret = 'SECRET'
-    options = { url: 'https://www.example.com', format: 'png' }
-    url_encoded_options = URI.encode_www_form(options)
-    token = OpenSSL::HMAC.hexdigest('sha1', api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
+      ClimateControl.modify URLBOX_API_SECRET: env_var_api_secret do
+        urlbox_client = Urlbox::Client.new(api_key: param_api_key)
 
-    stub_request(:get, "https://api.urlbox.io/v1/KEY/#{token}/png?format=png&url=https://www.example.com")
-      .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
-
-    urlbox_client = UrlboxClient.new(api_key: api_key, api_secret: api_secret)
-
-    response = urlbox_client.get(options)
-
-    assert response.status == 200
-    assert response.headers['Content-Type'].include?('png')
-  end
-
-  def test_successful_get_request_options_with_string_keys
-    param_api_key = 'KEY'
-    options = { 'url' => 'https://www.example.com' }
-
-    stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
-      .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
-
-    urlbox_client = UrlboxClient.new(api_key: param_api_key)
-
-    response = urlbox_client.get(options)
-
-    assert response.status == 200
-    assert response.headers['Content-Type'].include?('png')
-  end
-
-  # test delete
-  def test_delete_request
-    api_key = 'KEY'
-    options = { url: 'https://www.example.com' }
-
-    stub_request(:delete, 'https://api.urlbox.io/v1/KEY/png?format=png&url=https://www.example.com')
-      .to_return(status: 200, body: '', headers: {})
-
-    urlbox_client = UrlboxClient.new(api_key: api_key)
-
-    response = urlbox_client.delete(options)
-
-    assert response.status == 200
-  end
-
-  # test head
-  def test_head_request
-    api_key = 'KEY'
-    format = %w[png jpg jpeg avif webp pdf svg html].sample
-    url = 'https://www.example.com'
-
-    options = {
-      url: url,
-      format: format,
-      full_page: [true, false].sample,
-      width: [500, 700].sample
-    }
-
-    stub_request(:head, "https://api.urlbox.io/v1/#{api_key}/#{format}?format=#{format}&full_page=#{options[:full_page]}&url=#{url}&width=#{options[:width]}")
-      .to_return(status: 200, body: '', headers: {})
-
-    urlbox_client = UrlboxClient.new(api_key: api_key)
-
-    response = urlbox_client.head(options)
-
-    assert response.status == 200
-  end
-
-  # test post
-  def test_post_request_successful
-    api_key = 'KEY'
-    api_secret = 'SECRET'
-    options = {
-      url: 'https://www.example.com',
-      webhook_url: 'https://www.example.com/webhook'
-    }
-
-    stub_request(:post, 'https://api.urlbox.io/v1/render')
-      .with(
-        body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",
-        headers: {
-          'Authorization' => 'Bearer SECRET',
-          'Content-Type' => 'application/json'
-        }
-      ).to_return(status: 201)
-
-    urlbox_client = UrlboxClient.new(api_key: api_key, api_secret: api_secret)
-
-    response = urlbox_client.post(options)
-
-    assert response.status == 201
-  end
-
-  def test_post_request_successful_warning_missing_webhook_url
-    api_key = 'KEY'
-    api_secret = 'SECRET'
-    options = { url: 'https://www.example.com' }
-
-    stub_request(:post, 'https://api.urlbox.io/v1/render')
-      .with(
-        body: "{\"url\":\"https://www.example.com\",\"format\":\"png\"}",
-        headers: {
-          'Authorization' => 'Bearer SECRET',
-          'Content-Type' => 'application/json'
-        }
-      ).to_return(status: 201)
-
-    urlbox_client = UrlboxClient.new(api_key: api_key, api_secret: api_secret)
-
-    response = urlbox_client.post(options)
-
-    assert response.status == 201
-    # Wasn't able to test the warning message
-  end
-
-  def test_post_request_unsuccessful_missing_api_secret
-    api_key = 'KEY'
-    options = {
-      url: 'https://www.example.com',
-      webhook_url: 'https://www.example.com/webhook'
-    }
-
-    urlbox_client = UrlboxClient.new(api_key: api_key)
-
-    e = assert_raises Urlbox::UrlboxError do
-      urlbox_client.post(options)
+        assert_equal urlbox_client.instance_variable_get(:@api_secret), env_var_api_secret
+      end
     end
 
-    assert e.message.include? 'Missing api_secret'
-  end
+    def test_api_secret_provided_and_env_var_is_set
+      env_var_api_secret = 'ENV_VAR_SECRET'
+      param_api_secret = 'PARAM_SECRET'
+      param_api_key = 'PARAM_KEY'
 
-  # test generate_url
-  def test_generate_url_with_only_api_key
-    api_key = 'KEY'
-    options = { url: 'https://www.example.com', format: 'png' }
+      ClimateControl.modify URLBOX_API_SECRET: env_var_api_secret do
+        urlbox_client = Urlbox::Client.new(api_key: param_api_key, api_secret: param_api_secret)
 
-    urlbox_client = UrlboxClient.new(api_key: api_key)
+        # It sets the api_secret with the param, not the env var, value
+        assert_equal urlbox_client.instance_variable_get(:@api_secret), param_api_secret
+      end
+    end
 
-    urlbox_url = urlbox_client.generate_url(options)
+    def test_api_host_name_provided
+      param_api_key = 'PARAM_KEY'
+      api_host_name = ['api-eu.urlbox.io', 'api-direct.urlbox.io'].sample
 
-    assert_equal 'https://api.urlbox.io/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
-  end
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key, api_host_name: api_host_name)
 
-  def test_generate_url_with_api_key_and_secret
-    api_key = 'KEY'
-    api_secret = 'SECRET'
-    options = { url: 'https://www.example.com', format: 'png' }
-    url_encoded_options = URI.encode_www_form(options)
-    token = OpenSSL::HMAC.hexdigest('sha1', api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
+      # Use the api_host_name
+      assert_equal urlbox_client.instance_variable_get(:@base_api_url), "https://#{api_host_name}/"
+    end
 
-    urlbox_client = UrlboxClient.new(api_key: api_key, api_secret: api_secret)
+    def test_no_api_host_name_provided
+      param_api_key = 'PARAM_KEY'
 
-    urlbox_url = urlbox_client.generate_url(options)
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
 
-    assert_equal "https://api.urlbox.io/v1/KEY/#{token}/png?url=https%3A%2F%2Fwww.example.com&format=png", urlbox_url
-  end
+      # Use the default BASE_API_URL
+      assert_equal urlbox_client.instance_variable_get(:@base_api_url), Urlbox::Client::BASE_API_URL
+    end
 
-  # test module like methods
-  # get
-  def test_successful_class_get_request
-    env_var_api_key = 'ENV_VAR_KEY'
-    options = { url: 'https://www.example.com' }
+    def test_no_api_host_name_provided_but_env_var_is_set
+      param_api_key = 'PARAM_KEY'
+      env_var_api_host_name = 'ENV_VAR_HOST_NAME'
 
-    ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-      stub_request(:get, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+      ClimateControl.modify URLBOX_API_HOST_NAME: env_var_api_host_name do
+        urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+        assert_equal env_var_api_host_name, urlbox_client.instance_variable_get(:@base_api_url)
+      end
+    end
+
+    # Test get
+    def test_successful_get_request
+      param_api_key = 'KEY'
+      options = { url: 'https://www.example.com' }
+
+      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
-      response = UrlboxClient.get(options)
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+      response = urlbox_client.get(options)
 
       assert response.status == 200
       assert response.headers['Content-Type'].include?('png')
     end
-  end
 
-  # delete
-  def test_successful_class_delete_request
-    env_var_api_key = 'ENV_VAR_KEY'
-    options = { url: 'https://www.example.com' }
+    def test_successful_get_request_no_schema_url
+      param_api_key = 'KEY'
+      options = { url: 'www.example.com' }
 
-    ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-      stub_request(:delete, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=http://www.example.com")
+        .to_return(status: 200, body: '', headers: {})
+
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+      response = urlbox_client.get(options)
+
+      assert response.status == 200
+    end
+
+    def test_unsuccessful_get_invalid_url
+      param_api_key = 'KEY'
+      options = { url: 'FOO' }
+
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+      e = assert_raises Urlbox::Error do
+        urlbox_client.get(options)
+      end
+
+      assert_equal e.message, 'Invalid URL: http://FOO'
+    end
+
+    def test_unsuccessful_get_missing_url_or_html_entry_in_options
+      param_api_key = 'KEY'
+      options = { format: 'png' }
+
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+      e = assert_raises Urlbox::Error do
+        urlbox_client.get(options)
+      end
+
+      assert_equal e.message, 'Missing url or html entry in options'
+    end
+
+    def test_successful_get_request_authenticated
+      api_key = 'KEY'
+      api_secret = 'SECRET'
+      options = { url: 'https://www.example.com', format: 'png' }
+      url_encoded_options = URI.encode_www_form(options)
+      token = OpenSSL::HMAC.hexdigest('sha1', api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
+
+      stub_request(:get, "https://api.urlbox.io/v1/KEY/#{token}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
-      response = UrlboxClient.delete(options)
+      urlbox_client = Urlbox::Client.new(api_key: api_key, api_secret: api_secret)
+
+      response = urlbox_client.get(options)
 
       assert response.status == 200
       assert response.headers['Content-Type'].include?('png')
     end
-  end
 
-  # head
-  def test_successful_class_head_request
-    env_var_api_key = 'ENV_VAR_KEY'
-    options = { url: 'https://www.example.com' }
+    def test_successful_get_request_options_with_string_keys
+      param_api_key = 'KEY'
+      options = { 'url' => 'https://www.example.com' }
 
-    ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-      stub_request(:head, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
-      response = UrlboxClient.head(options)
+      urlbox_client = Urlbox::Client.new(api_key: param_api_key)
+
+      response = urlbox_client.get(options)
 
       assert response.status == 200
       assert response.headers['Content-Type'].include?('png')
     end
-  end
 
-  # post
-  def test_successful_class_post_request
-    api_key = 'KEY'
-    api_secret = 'SECRET'
-    options = {
-      url: 'https://www.example.com',
-      webhook_url: 'https://www.example.com/webhook'
-    }
+    # test delete
+    def test_delete_request
+      api_key = 'KEY'
+      options = { url: 'https://www.example.com' }
 
-    ClimateControl.modify URLBOX_API_KEY: api_key, URLBOX_API_SECRET: api_secret do
+      stub_request(:delete, 'https://api.urlbox.io/v1/KEY/png?format=png&url=https://www.example.com')
+        .to_return(status: 200, body: '', headers: {})
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key)
+
+      response = urlbox_client.delete(options)
+
+      assert response.status == 200
+    end
+
+    # test head
+    def test_head_request
+      api_key = 'KEY'
+      format = %w[png jpg jpeg avif webp pdf svg html].sample
+      url = 'https://www.example.com'
+
+      options = {
+        url: url,
+        format: format,
+        full_page: [true, false].sample,
+        width: [500, 700].sample
+      }
+
+      stub_request(:head, "https://api.urlbox.io/v1/#{api_key}/#{format}?format=#{format}&full_page=#{options[:full_page]}&url=#{url}&width=#{options[:width]}")
+        .to_return(status: 200, body: '', headers: {})
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key)
+
+      response = urlbox_client.head(options)
+
+      assert response.status == 200
+    end
+
+    # test post
+    def test_post_request_successful
+      api_key = 'KEY'
+      api_secret = 'SECRET'
+      options = {
+        url: 'https://www.example.com',
+        webhook_url: 'https://www.example.com/webhook'
+      }
+
       stub_request(:post, 'https://api.urlbox.io/v1/render')
         .with(
           body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",
@@ -374,9 +236,149 @@ class UrlboxClientTest < Minitest::Test
           }
         ).to_return(status: 201)
 
-      response = UrlboxClient.post(options)
+      urlbox_client = Urlbox::Client.new(api_key: api_key, api_secret: api_secret)
+
+      response = urlbox_client.post(options)
 
       assert response.status == 201
+    end
+
+    def test_post_request_successful_warning_missing_webhook_url
+      api_key = 'KEY'
+      api_secret = 'SECRET'
+      options = { url: 'https://www.example.com' }
+
+      stub_request(:post, 'https://api.urlbox.io/v1/render')
+        .with(
+          body: "{\"url\":\"https://www.example.com\",\"format\":\"png\"}",
+          headers: {
+            'Authorization' => 'Bearer SECRET',
+            'Content-Type' => 'application/json'
+          }
+        ).to_return(status: 201)
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key, api_secret: api_secret)
+
+      response = urlbox_client.post(options)
+
+      assert response.status == 201
+      # Wasn't able to test the warning message
+    end
+
+    def test_post_request_unsuccessful_missing_api_secret
+      api_key = 'KEY'
+      options = {
+        url: 'https://www.example.com',
+        webhook_url: 'https://www.example.com/webhook'
+      }
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key)
+
+      e = assert_raises Urlbox::Error do
+        urlbox_client.post(options)
+      end
+
+      assert e.message.include? 'Missing api_secret'
+    end
+
+    # test generate_url
+    def test_generate_url_with_only_api_key
+      api_key = 'KEY'
+      options = { url: 'https://www.example.com', format: 'png' }
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key)
+
+      urlbox_url = urlbox_client.generate_url(options)
+
+      assert_equal 'https://api.urlbox.io/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
+    end
+
+    def test_generate_url_with_api_key_and_secret
+      api_key = 'KEY'
+      api_secret = 'SECRET'
+      options = { url: 'https://www.example.com', format: 'png' }
+      url_encoded_options = URI.encode_www_form(options)
+      token = OpenSSL::HMAC.hexdigest('sha1', api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
+
+      urlbox_client = Urlbox::Client.new(api_key: api_key, api_secret: api_secret)
+
+      urlbox_url = urlbox_client.generate_url(options)
+
+      assert_equal "https://api.urlbox.io/v1/KEY/#{token}/png?url=https%3A%2F%2Fwww.example.com&format=png", urlbox_url
+    end
+
+    # test module like methods
+    # get
+    def test_successful_class_get_request
+      env_var_api_key = 'ENV_VAR_KEY'
+      options = { url: 'https://www.example.com' }
+
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        stub_request(:get, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+          .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
+
+        response = Urlbox::Client.get(options)
+
+        assert response.status == 200
+        assert response.headers['Content-Type'].include?('png')
+      end
+    end
+
+    # delete
+    def test_successful_class_delete_request
+      env_var_api_key = 'ENV_VAR_KEY'
+      options = { url: 'https://www.example.com' }
+
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        stub_request(:delete, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+          .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
+
+        response = Urlbox::Client.delete(options)
+
+        assert response.status == 200
+        assert response.headers['Content-Type'].include?('png')
+      end
+    end
+
+    # head
+    def test_successful_class_head_request
+      env_var_api_key = 'ENV_VAR_KEY'
+      options = { url: 'https://www.example.com' }
+
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        stub_request(:head, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+          .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
+
+        response = Urlbox::Client.head(options)
+
+        assert response.status == 200
+        assert response.headers['Content-Type'].include?('png')
+      end
+    end
+
+    # post
+    def test_successful_class_post_request
+      api_key = 'KEY'
+      api_secret = 'SECRET'
+      options = {
+        url: 'https://www.example.com',
+        webhook_url: 'https://www.example.com/webhook'
+      }
+
+      ClimateControl.modify URLBOX_API_KEY: api_key, URLBOX_API_SECRET: api_secret do
+        stub_request(:post, 'https://api.urlbox.io/v1/render')
+          .with(
+            body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",
+            headers: {
+              'Authorization' => 'Bearer SECRET',
+              'Content-Type' => 'application/json'
+            }
+          ).to_return(status: 201)
+
+        response = Urlbox::Client.post(options)
+
+        assert response.status == 201
+      end
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Refactors UrlboxClient -> Urlbox::Client and Urlbox::Error

#### Background context
We want to wrap all classes within the Urlbox module, to allow for extension of the code - more classes, etc.

