### PR TITLE
Add Urlbox::WebhookValiator class.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ AllCops:
   Exclude:
     - '*.gemspec'
   TargetRubyVersion: 2.5
+Layout/LineLength:
+  Enabled: true
+  Exclude:
+    - test/**/*
 Metrics/BlockLength:
   Enabled: true
   Exclude:
@@ -18,6 +22,9 @@ Metrics/MethodLength:
 Style/Documentation:
   Enabled: false
 Style/FrozenStringLiteralComment:
+  Enabled: false
+  Exclude:
+Style/GuardClause:
   Enabled: false
 Style/StringLiterals:
   Enabled: true

--- a/lib/urlbox/client.rb
+++ b/lib/urlbox/client.rb
@@ -1,5 +1,5 @@
 require 'http'
-require 'urlbox/error'
+require 'urlbox/errors'
 
 module Urlbox
   class Client

--- a/lib/urlbox/errors.rb
+++ b/lib/urlbox/errors.rb
@@ -7,4 +7,6 @@ module Urlbox
       ERROR_MESSAGE
     end
   end
+
+  class InvalidHeaderSignatureError < StandardError; end
 end

--- a/lib/urlbox/webhook_validator.rb
+++ b/lib/urlbox/webhook_validator.rb
@@ -1,0 +1,53 @@
+require 'urlbox/errors'
+
+module Urlbox
+  class WebhookValiator
+    SIGNATURE_REGEX = /^sha256=[0-9a-zA-Z]{40,}$/.freeze
+    TIMESTAMP_REGEX = /^t=[0-9]+$/.freeze
+    WEBHOOK_AGE_MAX_MINUTES = 5
+
+    class << self
+      def call(header_signature, payload, webhook_secret)
+        timestamp, signature = header_signature.split(',')
+
+        check_timestamp(timestamp)
+        check_signature(signature, timestamp, payload, webhook_secret)
+
+        true
+      end
+
+      def check_signature(raw_signature, timestamp, payload, webhook_secret)
+        raise Urlbox::InvalidHeaderSignatureError, 'Invalid signature' unless SIGNATURE_REGEX.match?(raw_signature)
+
+        signature_webhook = raw_signature.split('=')[1]
+        timestamp_parsed = timestamp.split('=')[1]
+        signature_generated =
+          OpenSSL::HMAC.hexdigest('sha256',
+                                  webhook_secret.encode('UTF-8'),
+                                  "#{timestamp_parsed}.#{JSON.dump(payload).encode('UTF-8')}")
+
+        raise Urlbox::InvalidHeaderSignatureError, 'Invalid signature' unless signature_generated == signature_webhook
+      end
+
+      def check_timestamp(raw_timestamp)
+        raise Urlbox::InvalidHeaderSignatureError, 'Invalid timestamp' unless TIMESTAMP_REGEX.match?(raw_timestamp)
+
+        timestamp = (raw_timestamp.split('=')[1]).to_i
+
+        check_webhook_creation_time(timestamp)
+      end
+
+      def check_webhook_creation_time(header_timestamp)
+        current_timestamp = Time.now.to_i
+        webhook_posted = current_timestamp - header_timestamp
+        webhook_posted_minutes_ago = webhook_posted / 60
+
+        if webhook_posted_minutes_ago > WEBHOOK_AGE_MAX_MINUTES
+          raise Urlbox::InvalidHeaderSignatureError, 'Invalid timestamp'
+        end
+      end
+    end
+
+    private_class_method :check_signature, :check_timestamp, :check_webhook_creation_time
+  end
+end

--- a/test/test_urlbox_webhook_validator.rb
+++ b/test/test_urlbox_webhook_validator.rb
@@ -1,0 +1,100 @@
+require 'climate_control'
+require 'minitest/autorun'
+require 'urlbox/webhook_validator'
+require 'webmock/minitest'
+
+module Urlbox
+  class WebhookValidatorTest < Minitest::Test
+    # helper functions
+
+    def header_signature
+      "t=#{timestamp_one_minute_ago},sha256=1e1b3c7f6b5f60f7b44ed1a85e653769ecf0c41ec5c7e8c131fc1a20357cc2b1"
+    end
+
+    def timestamp_one_minute_ago
+      (Time.now - 60).to_i
+    end
+
+    def payload
+      {
+        "event": "render.succeeded",
+        "renderId": "794383cd-b09e-4aef-a12b-fadf8aad9d63",
+        "result": {
+          "renderUrl": "https://renders.urlbox.io/urlbox1/renders/61431b47b8538a00086c29dd/2021/11/24/bee42850-bab6-43c6-bd9d-e614581d31b4.png"
+        },
+        "meta": {
+          "startTime": "2021-11-24T16:49:48.307Z",
+          "endTime": "2021-11-24T16:49:53.659Z"
+        }
+      }
+    end
+
+    def webhook_secret
+      "WEBHOOK_SECRET"
+    end
+    # helper functions - end
+
+    def test_call_valid_webhook
+      # Dynamically generate header signature to make the crypto comparision pass
+      payload_json_string = JSON.dump(payload)
+
+      signature_generated =
+        OpenSSL::HMAC.hexdigest('sha256',
+                                webhook_secret.encode('UTF-8'),
+                                "#{timestamp_one_minute_ago}.#{payload_json_string.encode('UTF-8')}")
+
+      header_signature = "t=#{timestamp_one_minute_ago},sha256=#{signature_generated}"
+
+      assert Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+    end
+
+    def test_call_invalid_signature
+      header_signature = "INVALID_SIGNATURE"
+
+      assert_raises Urlbox::InvalidHeaderSignatureError do
+        Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+      end
+    end
+
+    def test_call_invalid_hash_mismatch
+      header_signature = "t=#{timestamp_one_minute_ago},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+      e = assert_raises Urlbox::InvalidHeaderSignatureError do
+        Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+      end
+
+      assert_equal "Invalid signature", e.message
+    end
+
+    def test_call_invalid_hash_regex_catch
+      header_signature = "t=#{timestamp_one_minute_ago},sha256=invalid_hash_regex"
+
+      e = assert_raises Urlbox::InvalidHeaderSignatureError do
+        Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+      end
+
+      assert_equal "Invalid signature", e.message
+    end
+
+    def test_call_invalid_timestamp
+      header_signature = "t={invalid_timestamp},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+      e = assert_raises Urlbox::InvalidHeaderSignatureError do
+        Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+      end
+
+      assert_equal "Invalid timestamp", e.message
+    end
+
+    def test_call_invalid_timestamp_timing_attack
+      timestamp_ten_minute_ago = (Time.now - 600).to_i
+      header_signature = "t=#{timestamp_ten_minute_ago},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+      e = assert_raises Urlbox::InvalidHeaderSignatureError do
+        Urlbox::WebhookValiator.call(header_signature, payload, webhook_secret)
+      end
+
+      assert_equal "Invalid timestamp", e.message
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Adds Urlbox::WebhookValiator class.

#### Background context
This verifies the webhook is really from the Urlbox API.

Similar to Stripe, we want a series of checks to make sure that the webhook
is genuinely from UrlBox API and not a malicious actor.

Ref:
https://stripe.com/docs/webhooks/signatures#verify-manually

