### PR TITLE
Add generate_url as a class method.

### DIFF
--- a/lib/urlbox/client.rb
+++ b/lib/urlbox/client.rb
@@ -45,7 +45,6 @@ module Urlbox
           .post("#{@base_api_url}#{POST_END_POINT}", json: processed_options)
     end
 
-    # TODO: extract out to its own class
     def generate_url(options)
       processed_options, format = process_options(options)
 
@@ -62,7 +61,7 @@ module Urlbox
 
     # class methods to allow easy env var based usage
     class << self
-      %i[get delete head post].each do |method|
+      %i[delete head get post generate_url].each do |method|
         define_method(method) do |options|
           new.send(method, options)
         end

--- a/test/test_urlbox_client.rb
+++ b/test/test_urlbox_client.rb
@@ -380,5 +380,17 @@ module Urlbox
         assert response.status == 201
       end
     end
+
+    # generate_url
+    def test_successful_class_generate_url
+      env_var_api_key = 'KEY'
+      options = { url: 'https://www.example.com' }
+
+      ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
+        urlbox_url = Urlbox::Client.generate_url(options)
+
+        assert_equal 'https://api.urlbox.io/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Adds generate_url as a class method.

#### Background context
Similar to get, head, etc, we want to make sure that we can use the env
var magic module method for this method too.

