### PR TITLE
Add http and SSL dependencies to gemspec file. Update gem version to 0.1.3 🎉

### DIFF
--- a/urlbox.gemspec
+++ b/urlbox.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'urlbox'
-  spec.version       = '1.0.0'
+  spec.version       = '0.1.3'
   spec.authors       = ['Urlbox']
   spec.email         = ['support@urlbox.io']
 

--- a/urlbox.gemspec
+++ b/urlbox.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'urlbox'
-  spec.version       = '0.1.2'
+  spec.version       = '1.0.0'
   spec.authors       = ['Urlbox']
   spec.email         = ['support@urlbox.io']
 

--- a/urlbox.gemspec
+++ b/urlbox.gemspec
@@ -28,4 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.5'
+
+  spec.add_runtime_dependency 'http', ['~> 5.0']
+  spec.add_runtime_dependency 'openssl', ['~> 2.2']
 end


### PR DESCRIPTION
#### What's this PR do?
Add http and SSL dependencies to gemspec file.
~Updates gem version to 1.0.0 🎉~
Updates gem version to 0.1.3

#### Background context
On the **Add http and SSL dependencies to gemspec file.**
@jot discovered this gem was missing the http gem dependency. 👏

This should now include the http gem when a user installs this gem.

I have also added the openssl gem, as this was also in the Gemfile (used
when developing this gem and present in the Gemfile) but should have also
been added to the gemspec file.

**On the... Update version to 1.0.0**
I believe the plan was to refactor the Urlbox::Client to have methods
like: #create_render, rather then #get, but as this hasn't happened, I
think it makes sense to increase the version number to 1.0.0. So that
this is now a non-beta release.

Any big change such as using methods, called #create_render, etc, rather
than wrapping/ mapping to the underlying get request to the UrlBox API, can
be done as a version 2? It will need a fair bit of documentation though
as using #get, #post, etc as this does, maps quickly nicely to the existing
API docs.

But not today... We will keep it at < 1.0.0.

Further work is required to rename the methods from their mapping to http methods (get, post, etc) to more descriptive names (create_render, etc).
 
When that happens this will move to version 1.0.0. 


Once this is approved, I will push the updated gem to rubygems as per the _very_ useful wiki instructions... (https://github.com/urlbox/urlbox-ruby/wiki/Updating-The-Gem)

refs:
https://guides.rubygems.org/patterns/#declaring-dependencies

https://rubygems.org/gems/http
https://github.com/httprb/http

https://rubygems.org/gems/openssl
https://github.com/ruby/openssl

#### Where should the reviewer start?
Whole lot of waffle 👆 for 3 simple lines of change...

