### PR TITLE
feat(repo): update occurrences of .io with .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Give it a couple of seconds, and you should receive, posted to the webhook_url s
   "event": "render.succeeded",
   "renderId": "2cf5ffe2-7736-4d41-8c30-f13e16d35248",
   "result": {
-    "renderUrl": "https://renders.urlbox.io/urlbox1/renders/61431b47b8538a00086c29dd/2021/11/25/e2dcec18-8353-435c-ba17-b549c849eec5.png"
+    "renderUrl": "https://renders.urlbox.com/urlbox1/renders/61431b47b8538a00086c29dd/2021/11/25/e2dcec18-8353-435c-ba17-b549c849eec5.png"
   },
   "meta": {
     "startTime": "2021-11-25T16:32:32.453Z",
@@ -203,7 +203,7 @@ payload = {
   "event": "render.succeeded",
   "renderId": "794383cd-b09e-4aef-a12b-fadf8aad9d63",
   "result": {
-    "renderUrl": "https://renders.urlbox.io/urlbox1/renders/foo.png"
+    "renderUrl": "https://renders.urlbox.com/urlbox1/renders/foo.png"
   },
   "meta": {
     "startTime": "2021-11-24T16:49:48.307Z",

--- a/lib/urlbox/client.rb
+++ b/lib/urlbox/client.rb
@@ -3,7 +3,7 @@ require 'urlbox/errors'
 
 module Urlbox
   class Client
-    BASE_API_URL = 'https://api.urlbox.io/v1/'.freeze
+    BASE_API_URL = 'https://api.urlbox.com/v1/'.freeze
     POST_END_POINT = 'render'.freeze
 
     def initialize(api_key: nil, api_secret: nil, api_host_name: nil)

--- a/test/test_urlbox_client.rb
+++ b/test/test_urlbox_client.rb
@@ -63,7 +63,7 @@ module Urlbox
 
     def test_api_host_name_provided
       param_api_key = 'PARAM_KEY'
-      api_host_name = ['api-eu.urlbox.io', 'api-direct.urlbox.io'].sample
+      api_host_name = ['api-eu.urlbox.com', 'api-direct.urlbox.com'].sample
 
       urlbox_client = Urlbox::Client.new(api_key: param_api_key, api_host_name: api_host_name)
 
@@ -96,7 +96,7 @@ module Urlbox
       param_api_key = 'KEY'
       options = { url: 'https://www.example.com' }
 
-      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.com/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
       urlbox_client = Urlbox::Client.new(api_key: param_api_key)
@@ -111,7 +111,7 @@ module Urlbox
       param_api_key = 'KEY'
       options = { url: 'www.example.com' }
 
-      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=http://www.example.com")
+      stub_request(:get, "https://api.urlbox.com/v1/#{param_api_key}/png?format=png&url=http://www.example.com")
         .to_return(status: 200, body: '', headers: {})
 
       urlbox_client = Urlbox::Client.new(api_key: param_api_key)
@@ -154,7 +154,7 @@ module Urlbox
       url_encoded_options = URI.encode_www_form(options)
       token = OpenSSL::HMAC.hexdigest('sha1', api_secret.encode('UTF-8'), url_encoded_options.encode('UTF-8'))
 
-      stub_request(:get, "https://api.urlbox.io/v1/KEY/#{token}/png?format=png&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.com/v1/KEY/#{token}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
       urlbox_client = Urlbox::Client.new(api_key: api_key, api_secret: api_secret)
@@ -169,7 +169,7 @@ module Urlbox
       param_api_key = 'KEY'
       options = { 'url' => 'https://www.example.com' }
 
-      stub_request(:get, "https://api.urlbox.io/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.com/v1/#{param_api_key}/png?format=png&url=https://www.example.com")
         .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
       urlbox_client = Urlbox::Client.new(api_key: param_api_key)
@@ -189,7 +189,7 @@ module Urlbox
 
       urlbox_client = Urlbox::Client.new(api_key: api_key)
 
-      stub_request(:get, "https://api.urlbox.io/v1/KEY/png?format=png&header=x-my-second-header=someothervalue&url=https://www.example.com")
+      stub_request(:get, "https://api.urlbox.com/v1/KEY/png?format=png&header=x-my-second-header=someothervalue&url=https://www.example.com")
         .to_return(status: 200, body: "", headers: {})
 
       response = urlbox_client.get(options)
@@ -202,7 +202,7 @@ module Urlbox
       api_key = 'KEY'
       options = { url: 'https://www.example.com' }
 
-      stub_request(:delete, 'https://api.urlbox.io/v1/KEY/png?format=png&url=https://www.example.com')
+      stub_request(:delete, 'https://api.urlbox.com/v1/KEY/png?format=png&url=https://www.example.com')
         .to_return(status: 200, body: '', headers: {})
 
       urlbox_client = Urlbox::Client.new(api_key: api_key)
@@ -225,7 +225,7 @@ module Urlbox
         width: [500, 700].sample
       }
 
-      stub_request(:head, "https://api.urlbox.io/v1/#{api_key}/#{format}?format=#{format}&full_page=#{options[:full_page]}&url=#{url}&width=#{options[:width]}")
+      stub_request(:head, "https://api.urlbox.com/v1/#{api_key}/#{format}?format=#{format}&full_page=#{options[:full_page]}&url=#{url}&width=#{options[:width]}")
         .to_return(status: 200, body: '', headers: {})
 
       urlbox_client = Urlbox::Client.new(api_key: api_key)
@@ -244,7 +244,7 @@ module Urlbox
         webhook_url: 'https://www.example.com/webhook'
       }
 
-      stub_request(:post, 'https://api.urlbox.io/v1/render')
+      stub_request(:post, 'https://api.urlbox.com/v1/render')
         .with(
           body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",
           headers: {
@@ -265,7 +265,7 @@ module Urlbox
       api_secret = 'SECRET'
       options = { url: 'https://www.example.com' }
 
-      stub_request(:post, 'https://api.urlbox.io/v1/render')
+      stub_request(:post, 'https://api.urlbox.com/v1/render')
         .with(
           body: "{\"url\":\"https://www.example.com\",\"format\":\"png\"}",
           headers: {
@@ -307,7 +307,7 @@ module Urlbox
 
       urlbox_url = urlbox_client.generate_url(options)
 
-      assert_equal 'https://api.urlbox.io/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
+      assert_equal 'https://api.urlbox.com/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
     end
 
     def test_generate_url_with_api_key_and_secret
@@ -321,7 +321,7 @@ module Urlbox
 
       urlbox_url = urlbox_client.generate_url(options)
 
-      assert_equal "https://api.urlbox.io/v1/KEY/#{token}/png?url=https%3A%2F%2Fwww.example.com&format=png", urlbox_url
+      assert_equal "https://api.urlbox.com/v1/KEY/#{token}/png?url=https%3A%2F%2Fwww.example.com&format=png", urlbox_url
     end
 
     # test module like methods
@@ -331,7 +331,7 @@ module Urlbox
       options = { url: 'https://www.example.com' }
 
       ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-        stub_request(:get, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+        stub_request(:get, "https://api.urlbox.com/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
           .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
         response = Urlbox::Client.get(options)
@@ -347,7 +347,7 @@ module Urlbox
       options = { url: 'https://www.example.com' }
 
       ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-        stub_request(:delete, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+        stub_request(:delete, "https://api.urlbox.com/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
           .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
         response = Urlbox::Client.delete(options)
@@ -363,7 +363,7 @@ module Urlbox
       options = { url: 'https://www.example.com' }
 
       ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
-        stub_request(:head, "https://api.urlbox.io/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
+        stub_request(:head, "https://api.urlbox.com/v1/#{env_var_api_key}/png?format=png&url=https://www.example.com")
           .to_return(status: 200, body: '', headers: { 'content-type': 'image/png' })
 
         response = Urlbox::Client.head(options)
@@ -383,7 +383,7 @@ module Urlbox
       }
 
       ClimateControl.modify URLBOX_API_KEY: api_key, URLBOX_API_SECRET: api_secret do
-        stub_request(:post, 'https://api.urlbox.io/v1/render')
+        stub_request(:post, 'https://api.urlbox.com/v1/render')
           .with(
             body: "{\"url\":\"https://www.example.com\",\"webhook_url\":\"https://www.example.com/webhook\",\"format\":\"png\"}",
             headers: {
@@ -406,7 +406,7 @@ module Urlbox
       ClimateControl.modify URLBOX_API_KEY: env_var_api_key do
         urlbox_url = Urlbox::Client.generate_url(options)
 
-        assert_equal 'https://api.urlbox.io/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
+        assert_equal 'https://api.urlbox.com/v1/KEY/png?url=https%3A%2F%2Fwww.example.com&format=png', urlbox_url
       end
     end
   end


### PR DESCRIPTION
#### What's this PR do?

Updates all occurrences of .io with .com in:
- README.md
- client.rb (the base URL)
- Test files (and checked they are passing by running `rake` in the root dir after a `bundle install`)

#### How should this be manually tested?

Run the tests in the root dir using `rake` after a `bundle install`